### PR TITLE
Eks karpenter 20.31.6 upgrade

### DIFF
--- a/access_entries.tf
+++ b/access_entries.tf
@@ -1,6 +1,6 @@
 locals {
   eks_cluster_admin_entries = {
-    for admin in var.eks_cluster_admins : admin.username => {
+    for admin in var.cluster_admins : admin.username => {
       principal_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${admin.path}/${admin.username}"
       type          = "STANDARD"
       policy_associations = {

--- a/access_entries.tf
+++ b/access_entries.tf
@@ -1,7 +1,7 @@
 locals {
   eks_cluster_admin_entries = {
     for admin in var.cluster_admins : admin.username => {
-      principal_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${admin.path}/${admin.username}"
+      principal_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user${admin.path}${admin.username}"
       type          = "STANDARD"
       policy_associations = {
         admin = {

--- a/access_entries.tf
+++ b/access_entries.tf
@@ -1,0 +1,21 @@
+locals {
+  eks_cluster_admin_entries = {
+    for admin in var.eks_cluster_admins : admin.username => {
+      principal_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${admin.path}/${admin.username}"
+      type          = "STANDARD"
+      policy_associations = {
+        admin = {
+          policy_arn = "arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"
+          access_scope = {
+            type = "cluster"
+          }
+        }
+      }
+    }
+  }
+
+  merged_access_entries = merge(
+    local.eks_cluster_admin_entries,
+    var.access_entries,
+  )
+}

--- a/eks.tf
+++ b/eks.tf
@@ -147,4 +147,6 @@ module "eks_aws_auth" {
       groups   = user["groups"]
     }
   ]
+
+  depends_on = [module.eks]
 }

--- a/eks.tf
+++ b/eks.tf
@@ -1,6 +1,6 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "19.21.0"
+  version = "20.31.6"
 
   cluster_name                         = var.eks_cluster_name
   cluster_version                      = var.eks_cluster_version
@@ -17,14 +17,12 @@ module "eks" {
 
   cluster_addons = {
     coredns = {
-      addon_version     = var.addons_versions.coredns
-      resolve_conflicts = "OVERWRITE"
+      addon_version = var.addons_versions.coredns
     }
     kube-proxy = {
       addon_version = var.addons_versions.kube_proxy
     }
     vpc-cni = {
-      resolve_conflicts        = "OVERWRITE"
       service_account_role_arn = module.vpc_cni_irsa.iam_role_arn
     }
   }
@@ -108,6 +106,27 @@ module "eks" {
     }
   }
 
+  tags                          = var.eks_tags
+  kms_key_enable_default_policy = var.kms_key_enable_default_policy
+  kms_key_users                 = var.kms_key_users
+
+}
+
+resource "aws_eks_addon" "ebs-csi" {
+  cluster_name             = module.eks.cluster_name
+  addon_name               = "aws-ebs-csi-driver"
+  addon_version            = var.addons_versions.ebs_csi
+  service_account_role_arn = module.irsa-ebs-csi.iam_role_arn
+  tags = merge(
+    var.eks_tags,
+    tomap({ eks_addon = "ebs_csi" })
+  )
+}
+
+module "eks_aws_auth" {
+  source  = "terraform-aws-modules/eks/aws//modules/aws-auth"
+  version = "20.31.6"
+
   manage_aws_auth_configmap = true
 
   aws_auth_roles = [
@@ -125,20 +144,4 @@ module "eks" {
       groups   = user["groups"]
     }
   ]
-
-  tags                          = var.eks_tags
-  kms_key_enable_default_policy = var.kms_key_enable_default_policy
-  kms_key_users                 = var.kms_key_users
-
-}
-
-resource "aws_eks_addon" "ebs-csi" {
-  cluster_name             = module.eks.cluster_name
-  addon_name               = "aws-ebs-csi-driver"
-  addon_version            = var.addons_versions.ebs_csi
-  service_account_role_arn = module.irsa-ebs-csi.iam_role_arn
-  tags = merge(
-    var.eks_tags,
-    tomap({ eks_addon = "ebs_csi" })
-  )
 }

--- a/eks.tf
+++ b/eks.tf
@@ -10,6 +10,9 @@ module "eks" {
   cluster_security_group_name          = "${var.eks_cluster_name}-sg"
   enable_irsa                          = true
 
+  # TODO: Remove when upgrading to v21
+  enable_cluster_creator_admin_permissions = true
+
   ## Control plane logging
   create_cloudwatch_log_group            = true
   cluster_enabled_log_types              = var.cluster_enabled_log_types

--- a/eks.tf
+++ b/eks.tf
@@ -11,7 +11,7 @@ module "eks" {
   enable_irsa                          = true
 
   # TODO: Remove when upgrading to v21
-  enable_cluster_creator_admin_permissions = true
+  enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
 
   ## Control plane logging
   create_cloudwatch_log_group            = true

--- a/eks.tf
+++ b/eks.tf
@@ -10,8 +10,7 @@ module "eks" {
   cluster_security_group_name          = "${var.eks_cluster_name}-sg"
   enable_irsa                          = true
 
-  # TODO: Remove when upgrading to v21
-  enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
+  access_entries = local.merged_access_entries
 
   ## Control plane logging
   create_cloudwatch_log_group            = true
@@ -124,29 +123,4 @@ resource "aws_eks_addon" "ebs-csi" {
     var.eks_tags,
     tomap({ eks_addon = "ebs_csi" })
   )
-}
-
-module "eks_aws_auth" {
-  source  = "terraform-aws-modules/eks/aws//modules/aws-auth"
-  version = "20.31.6"
-
-  manage_aws_auth_configmap = true
-
-  aws_auth_roles = [
-    for role in var.eks_aws_auth_roles : {
-      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${role["rolearn"]}"
-      username = role["username"]
-      groups   = role["groups"]
-    }
-  ]
-
-  aws_auth_users = [
-    for user in var.eks_aws_auth_users : {
-      userarn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user${var.eks_aws_users_path}${user["username"]}"
-      username = user["username"]
-      groups   = user["groups"]
-    }
-  ]
-
-  depends_on = [module.eks]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.1"
+  required_version = ">= 1.3"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.20"
+      version = ">= 5.34"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/variables.tf
+++ b/variables.tf
@@ -89,7 +89,7 @@ variable "cluster_admins" {
   type = list(
     object({
       username = string
-      path     = optional(string, "users")
+      path     = optional(string, "/users/")
     })
   )
   default = []

--- a/variables.tf
+++ b/variables.tf
@@ -80,39 +80,25 @@ variable "addons_versions" {
   })
 }
 
-variable "eks_aws_auth_roles" {
-  type = list(object({
-    rolearn  = string
-    username = string
-    groups   = list(string)
-  }))
-  default = []
-}
-
-variable "eks_aws_auth_users" {
-  type = list(object({
-    username = string
-    groups   = list(string)
-  }))
-  default = []
-}
-
-variable "eks_aws_users_path" {
-  type        = string
-  description = "The organizational path of the user used for building the arn , by default it's just / "
-  default     = "/"
-}
-
 variable "eks_tags" {
   type    = map(string)
   default = {}
 }
 
-# TODO: Remove when upgrading to v21
-variable "enable_cluster_creator_admin_permissions" {
-  description = "Indicates whether or not to add the cluster creator (the identity used by Terraform) as an administrator via access entry"
-  type        = bool
-  default     = false
+variable "eks_cluster_admins" {
+  type = list(
+    object({
+      username = string
+      path     = optional(string, "users")
+    })
+  )
+  default = []
+}
+
+variable "access_entries" {
+  type        = any
+  description = "Map of access entries to add to the cluster"
+  default     = {}
 }
 
 ################################################################################

--- a/variables.tf
+++ b/variables.tf
@@ -85,7 +85,7 @@ variable "eks_tags" {
   default = {}
 }
 
-variable "eks_cluster_admins" {
+variable "cluster_admins" {
   type = list(
     object({
       username = string

--- a/variables.tf
+++ b/variables.tf
@@ -108,6 +108,12 @@ variable "eks_tags" {
   default = {}
 }
 
+# TODO: Remove when upgrading to v21
+variable "enable_cluster_creator_admin_permissions" {
+  description = "Indicates whether or not to add the cluster creator (the identity used by Terraform) as an administrator via access entry"
+  type        = bool
+  default     = false
+}
 
 ################################################################################
 # Node group defaults 


### PR DESCRIPTION
- Upgraded EKS module to `20.31.6`
- Migrated from `aws-auth` ConfigMap to `access_entries`.
- Cleaned up unused variables and enforced Terraform `>= 1.3`  and the AWS provider to `>= 5.34`.. 